### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -52,6 +53,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -86,6 +88,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -127,6 +130,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 


### PR DESCRIPTION
This allows us to see (and fail on) PHP warnings and notices.

Fixes #156